### PR TITLE
Add mac80211_hwsim configuration

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,24 @@
+# mac80211_hwsim demo
+- Hostapd set up
+```shell
+sudo service network-manager stop
+
+sudo modprobe -r mac80211_hwsim
+sudo modprobe mac80211_hwsim radios=2
+sudo hostapd hostapd_open.conf -i wlan0
+sudo ip addr add 192.168.42.1/24 dev wlan0
+```
+- Station set up
+```shell
+sudo wpa_supplicant -Dnl80211 -iwlan1 -c wpa_supplicant.conf
+```
+- DHCP Setup
+```shell
+sudo dhcpd -cf dhcpd.conf wlan0
+sudo dhclient -4 wlan1
+```
+## trace_cmd
+```
+trace-cmd record -p function -l '*80211*' iw dev wlan1 set channel 8
+trace-cmd report
+```

--- a/scripts/hostapd_open.conf
+++ b/scripts/hostapd_open.conf
@@ -1,0 +1,8 @@
+interface=wlan0
+driver=nl80211
+ssid=octobersky
+country_code=US
+hw_mode=g
+channel=1
+auth_algs=1
+wpa=0

--- a/scripts/hostapd_wpa.conf
+++ b/scripts/hostapd_wpa.conf
@@ -1,0 +1,9 @@
+interface=wlan0
+driver=nl80211
+hw_mode=g
+channel=1
+ssid=octobersky_wpa
+wpa=2
+wpa_key_mgmt=WPA-PSK
+wpa_pairwise=CCMP
+wpa_passphrase=12345678

--- a/scripts/wpa_supplicant.conf
+++ b/scripts/wpa_supplicant.conf
@@ -1,0 +1,5 @@
+ctrl_interface=/var/run/wpa_supplicant 
+network={
+    ssid="octobersky"
+    key_mgmt=NONE
+}


### PR DESCRIPTION
1. Add mac80211_hwsim demo configuration which include hostapd and wpa_supplicant.
    - Create a AP as a mock for "owl0 wifi"
    - In the future, "owl0" will replace the wpa_supplicant interface wlan0 
2. Fix verify.sh could not find common.sh file.