### PR TITLE
Use hash table to store AP information

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -25,3 +25,5 @@ ForEachMacros:
   - rb_list_foreach
   - rb_list_foreach_safe
   - vec_foreach
+  - hash_for_each_possible_safe
+  - hash_for_each_safe

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ sudo modprobe cfg80211
 
 Insert `vwifi` driver:
 ```shell
-sudo insmod vwifi.ko ssid_list='[MyWifi_1][MyWifi_2][MyHomeWifi]'
+sudo insmod vwifi.ko ssid_list='[MyHomeWiFi][MyWifi_1][MyWifi_2]'
 ```
 
 Check network interfaces:
@@ -103,7 +103,7 @@ sudo iw dev owl0 connect MyHomeWiFi
 
 Validate the connection:
 ```shell
-iwconfig owl0
+sudo iw dev owl0 link
 ```
 
 Reference output:
@@ -116,7 +116,7 @@ owl0      IEEE 802.11  ESSID:"MyHomeWiFi"
 
 Change wifi list:
 ```
-echo -n "[MyWifi_1][MyWifi_2][MyWifi_3]" | sudo tee /sys/module/vwifi/parameters/ssid_list
+echo -n "[MyHomeWiFi][MyWifi_1][MyWifi_2]" | sudo tee /sys/module/vwifi/parameters/ssid_list
 ```
 
 SSID Naming Convention:

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -17,9 +17,9 @@ fi
 
 if [ $final_ret -eq 0 ]; then
     sudo ip link set owl0 up
-    sudo iw dev owl0 scan | grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}'| tr [:lower:] [:upper:] > scan_bssid.log
+    sudo iw dev owl0 scan | grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}'| head -n 1 > scan_bssid.log
     sudo iw dev owl0 connect MyHomeWiFi
-    iwconfig owl0 | grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}' > connected.log
+    sudo iw dev owl0 link 2> /dev/null | grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}' > connected.log
 
     DIFF=$(diff connected.log scan_bssid.log)
     if [ "$DIFF" != "" ]; then


### PR DESCRIPTION
1. Use `strspn` and `strcspn` to parsing the parameter.
2. Store the AP information into hash table which is `ap_info_hash` 