### PR TITLE
Fix possible buffer overflow

### DIFF
--- a/vwifi.c
+++ b/vwifi.c
@@ -33,7 +33,7 @@ struct owl_context {
 
     struct mutex lock;
     struct work_struct ws_connect, ws_disconnect;
-    char connecting_ssid[SSID_MAX_LENGTH];
+    char connecting_ssid[SSID_MAX_LENGTH + 1]; /* plus one for '\0' */
     u16 disconnect_reason_code;
     struct work_struct ws_scan;
     struct cfg80211_scan_request *scan_request;


### PR DESCRIPTION
In `owl_connect()`, when  `sme->ssid_len` is greater than or equal to `SSID_MAX_LENGTH`, `ssid_len` will be assign to `SSID_MAX_LENGTH`, and a buffer overflow will occur when adding NULL terminator at `owl->connecting_ssid[ssid_len]`.