### PR TITLE
Add TSF support

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ sudo iw dev owl0 scan
 You should get the following:
 ```
 BSS ca:9c:00:c6:c2:eb(on owl0)
-	TSF: 0 usec (0d, 00:00:00)
+	TSF: 47065806941 usec (0d, 13:04:25)
 	freq: 2437
 	beacon interval: 100 TUs
 	capability: ESS (0x0001)

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -16,8 +16,12 @@ if [ $? -ne 0 ]; then
 fi
 
 if [ $final_ret -eq 0 ]; then
+    # to avoid device or resource busy error
+    sleep 0.5
+
     sudo ip link set owl0 up
-    sudo iw dev owl0 scan | grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}'| head -n 1 > scan_bssid.log
+    sudo iw dev owl0 scan > scan_result.log
+    cat scan_result.log | grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}'| head -n 1 > scan_bssid.log
     sudo iw dev owl0 connect MyHomeWiFi
     sudo iw dev owl0 link | grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}' > connected.log
 
@@ -25,11 +29,22 @@ if [ $final_ret -eq 0 ]; then
     if [ "$DIFF" != "" ]; then
         final_ret=3
     fi
+
+    # verify TSF (in usec)
+    tsf=$(cat scan_result.log | grep "TSF" | awk '{print $2}')
+    uptime=$(cat /proc/uptime | awk '{print $1}')
+    uptime=$(echo "$uptime*1000000" | bc | awk -F "." '{print $1}')
+    diff=$((tsf - uptime))
+
+    # difference between tsf and uptime should less than 0.5 sec.
+    if [ "${diff#-}" -gt 500000 ]; then
+        final_ret=4
+    fi
 fi
 
 if [ $final_ret -eq 0 ]; then
     remove_kmod vwifi
-    rm scan_bssid.log connected.log
+    rm scan_result.log scan_bssid.log connected.log
     echo "==== Test PASSED ===="
     exit 0
 fi

--- a/vwifi.c
+++ b/vwifi.c
@@ -186,9 +186,16 @@ static void inform_dummy_bss(struct owl_context *owl)
         ie[1] = ssid_len;
         memcpy(ie + 2, ap->ssid, ssid_len);
 
+        /* Using CLOCK_BOOTTIME clock, which won't be affected by
+         * changes in system time-of-day clock, and includes any time
+         * that the system is suspended. Thus, it's suitable for
+         * tsf to synchronize the machines in BSS.
+         */
+        u64 tsf = div_u64(ktime_get_boottime_ns(), 1000);
+
         /* It is posible to use cfg80211_inform_bss() instead. */
         bss = cfg80211_inform_bss_data(
-            owl->wiphy, &data, CFG80211_BSS_FTYPE_UNKNOWN, ap->bssid, 0,
+            owl->wiphy, &data, CFG80211_BSS_FTYPE_UNKNOWN, ap->bssid, tsf,
             WLAN_CAPABILITY_ESS, 100, ie, ssid_len + 2, GFP_KERNEL);
 
         /* cfg80211_inform_bss_data() returns cfg80211_bss structure referefence


### PR DESCRIPTION
Rewriting some code with wrapper macro/function, like replacing
cfg80211_inform_bss_data() with cfg80211_inform_bss(), and so on.
I also add tsf support which provides timing information while
performing cfg80211_ops->scan() routine.
Fix possible buffer overflow by increment the size of every array
to 33, which can tolerate 32 characters (defined by IEEE 802.11
standard) plus one NULL terminator.