### PR TITLE
Check kernel version for netif_rx_ni()

### DIFF
--- a/vwifi.c
+++ b/vwifi.c
@@ -6,6 +6,7 @@
 #include <linux/skbuff.h>
 #include <linux/string.h>
 #include <linux/timer.h>
+#include <linux/version.h>
 #include <linux/workqueue.h>
 #include <net/cfg80211.h>
 
@@ -324,7 +325,11 @@ static void owl_rx(struct net_device *dev)
     skb->dev = dev;
     skb->protocol = eth_type_trans(skb, dev);
     skb->ip_summed = CHECKSUM_UNNECESSARY; /* don't check it */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 18, 0)
     netif_rx_ni(skb);
+#else
+    netif_rx(skb);
+#endif
 
     return;
 


### PR DESCRIPTION
According to this patch [1], kernel developers
prepared to replace netif_rx_ni() with netif_rx(). They modified netif_rx() and implement
netif_rx_ni() as a wrapper of netif_rx().

In the following patch [2], netif_rx_ni() was
removed. This patch was mentioned in networking
changes for 5.18.[3]

For the compatibility, I check kernel version
before calling netif_rx_ni().

[1]https://lore.kernel.org/netdev/20220202122848.647635-4-bigeasy@linutronix.de/ [2]https://lore.kernel.org/netdev/20220306215753.3156276-10-bigeasy@linutronix.de/ [3]https://lore.kernel.org/netdev/20220323180738.3978487-1-kuba@kernel.org/