### PR TITLE
Replace env variable by shell function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ KDIR ?= /lib/modules/$(shell uname -r)/build
 GIT_HOOKS := .git/hooks/applied
 
 all:
-	$(MAKE) -C $(KDIR) M=$(PWD) modules
+	$(MAKE) -C $(KDIR) M=$(shell pwd) modules
 
 clean:
-	$(MAKE) -C $(KDIR) M=$(PWD) clean
+	$(MAKE) -C $(KDIR) M=$(shell pwd) clean
 
 check: all
 	@scripts/verify.sh


### PR DESCRIPTION
The `$PWD` environment variable doesn't exist when we run `sudo make`, so the `PWD` in Makefile will be
evaulated to an empty string. Replace unreliable `PWD` by shell function `$(shell pwd)`.