### PR TITLE
Avoid directly modifying ndev->dev_addr

### DIFF
--- a/vwifi.c
+++ b/vwifi.c
@@ -844,7 +844,7 @@ static struct wireless_dev *owinterface_add(struct wiphy *wiphy, int if_idx)
      */
     char intf_name[ETH_ALEN] = {0};
     snprintf(intf_name + 1, ETH_ALEN, "%s%d", NAME_PREFIX, if_idx);
-    memcpy(vif->ndev->dev_addr, intf_name, ETH_ALEN);
+    eth_hw_addr_set(vif->ndev, intf_name);
 
     /* register network device. If everything is ok, there should be new
      * network device: $ ip a


### PR DESCRIPTION
Commit [406f42fa0d](https://scm.linefinity.com/common/linux-stable/commit/406f42fa0d3c) from linux kernel introduced a rbtree for faster Ethernet address look up. To maintain netdev->dev_addr in this tree we need to make all the writes to it go through appropriate helpers.