### PR TITLE
Support passive scan

### DIFF
--- a/scripts/hostapd.conf
+++ b/scripts/hostapd.conf
@@ -2,10 +2,14 @@ interface=owl0
 driver=nl80211
 debug=1
 ctrl_interface=/var/run/hostapd
-ctrl_interface_group=wheel
+ctrl_interface_group=0
 channel=6
 ssid=test
 wpa=2
 wpa_passphrase=12345678
 wpa_key_mgmt=WPA-PSK
 wpa_pairwise=CCMP
+
+# Beacon interval (kibi-us : 1.024 ms)
+beacon_int=100
+dtim_period=1

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -73,7 +73,7 @@ if [ $final_ret -eq 0 ]; then
     # STA owl1 performs scan and connect to TestAP
     sudo ip netns exec ns1 iw dev owl1 scan > scan_result.log
     cat scan_result.log | grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}'| tail -n 1 > scan_bssid.log
-    sudo ip netns exec ns1 iw dev owl1 connect TestAP
+    sudo ip netns exec ns1 iw dev owl1 connect test
     sudo ip netns exec ns1 iw dev owl1 link | grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}' > connected.log
 
     DIFF=$(diff connected.log scan_bssid.log)
@@ -89,7 +89,7 @@ if [ $final_ret -eq 0 ]; then
     # STA owl2 performs scan and connect to TestAP
     sudo ip netns exec ns2 iw dev owl2 scan > scan_result.log
     cat scan_result.log | grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}'| tail -n 1 > scan_bssid.log
-    sudo ip netns exec ns2 iw dev owl2 connect TestAP
+    sudo ip netns exec ns2 iw dev owl2 connect test
     sudo ip netns exec ns2 iw dev owl2 link | grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}' > connected.log
 
     DIFF=$(diff connected.log scan_bssid.log)


### PR DESCRIPTION
Two changes were made in this commit:
(1) Passive scanning of vwifi: Once we execute hostapd to start AP mode , it will initialize an htrimer and set its countdown time to the beacon interval input by the user application. When the time is up, the callback function will be triggered, and it will Pass the AP's beacon to other stations.
(2) Supports 5 GHZ band: The frequency is calculated as 5 GHz + (5 * channel index).

Finally, some errors in vwifi will be corrected so that verify.sh can be executed correctly.