### PR TITLE
Correct the used of snprintf in owinterface_add

### DIFF
--- a/vwifi.c
+++ b/vwifi.c
@@ -1216,7 +1216,7 @@ static struct wireless_dev *owinterface_add(struct wiphy *wiphy, int if_idx)
      * address (the first byte of multicast addrs is odd).
      */
     char intf_name[ETH_ALEN] = {0};
-    snprintf(intf_name + 1, ETH_ALEN, "%s%d", NAME_PREFIX, if_idx);
+    snprintf(intf_name + 1, ETH_ALEN - 1, "%s%d", NAME_PREFIX, if_idx);
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 0)
     eth_hw_addr_set(vif->ndev, intf_name);


### PR DESCRIPTION
* origin size put in snprintf in function owinterface_add was wrong
* correct the size from ETH_ALEN to ETH_ALEN - 1

The origin `size` value in `snprintf` of `owinterface_add` was `ETH_ALEN`, which will only allow ETH_ALEN - 1 characters to write in the buffer when string size is too long.

However, since the buffer starts from `inf_name + 1`, which only allow `ETH_ALEN - 1` characters to be written into, plus the last character must be `'\0'`, so we should only allow `ETH_ALEN - 2` character to be written into the buffer.

That's why I create the PR and fix the `size` value to `ETH_ALEN - 1`