### PR TITLE
Implement customized naming for wiphy

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,11 +125,11 @@ $ sudo iw list
 
 Reference output:
 ```
-Wiphy phy2
+Wiphy vw_phy2
 (... omit)
-Wiphy phy1
+Wiphy vw_phy1
 (... omit)
-Wiphy phy0
+Wiphy vw_phy0
 	wiphy index: 0
 	max # scan SSIDs: 69
 	max scan IEs length: 0 bytes
@@ -205,12 +205,34 @@ $ sudo ip netns add ns1
 $ sudo ip netns add ns2
 ````
 
+Find the `wiphy` name for the three interfaces.
+The index number for the `wiphy` name postfix might be different each time.
+Please use the following command for the ease of memorizing different index number everytime.
+```shell
+$ vw0_phy=$(sudo iw dev vw0 info | grep wiphy | awk '{print $2}')
+$ vw0_phy=$(sudo iw list | grep "wiphy index: $vw0_phy" -B 1 | grep Wiphy | awk '{print $2}')
+$ vw1_phy=$(sudo iw dev vw1 info | grep wiphy | awk '{print $2}')
+$ vw1_phy=$(sudo iw list | grep "wiphy index: $vw1_phy" -B 1 | grep Wiphy | awk '{print $2}')
+$ vw2_phy=$(sudo iw dev vw2 info | grep wiphy | awk '{print $2}')
+$ vw2_phy=$(sudo iw list | grep "wiphy index: $vw2_phy" -B 1 | grep Wiphy | awk '{print $2}')
+```
+
+Check whether the name of each `wiphy` is the same as the name listing under the command `sudo iw list`
+```shell
+$ echo $vw0_phy
+vw_phy0
+$ echo $vw1_phy
+vw_phy1
+$ echo $vw2_phy
+vw_phy2
+```
+
 Assign the three interfaces to separate network namespaces.
 Please note that the `wiphy` is placed within the network namespace, and the interface associated with that wiphy will be contained within it.
 ```shell
-$ sudo iw phy phy0 set netns name ns0
-$ sudo iw phy phy1 set netns name ns1
-$ sudo iw phy phy2 set netns name ns2
+$ sudo iw phy $vw_phy0 set netns name ns0
+$ sudo iw phy $vw_phy1 set netns name ns1
+$ sudo iw phy $vw_phy2 set netns name ns2
 ```
 
 ### Assigning IP Addresses to Each Interface

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -65,3 +65,10 @@ function stop_hostapd() {
 	sudo kill -9 $(pidof hostapd) > /dev/null
 	return 0
 }
+
+function get_wiphy_name() {
+    local interface_name=$1
+    local wiphy_name=$(sudo iw dev $interface_name info | grep wiphy | awk '{print $2}')
+    wiphy_name=$(sudo iw list | grep "wiphy index: $wiphy_name" -B 1 | grep Wiphy | awk '{print $2}')
+    echo $wiphy_name
+}

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -26,12 +26,9 @@ if [ $final_ret -eq 0 ]; then
 
     # get phy number of each interface
     sudo iw dev > device.log
-    vw0_phy=$(cat device.log | grep -B 1 vw0 | grep phy)
-    vw0_phy=${vw0_phy/\#/}
-    vw1_phy=$(cat device.log | grep -B 1 vw1 | grep phy)
-    vw1_phy=${vw1_phy/\#/}
-    vw2_phy=$(cat device.log | grep -B 1 vw2 | grep phy)
-    vw2_phy=${vw2_phy/\#/}
+    vw0_phy=$(get_wiphy_name vw0)
+    vw1_phy=$(get_wiphy_name vw1)
+    vw2_phy=$(get_wiphy_name vw2)
     
     # create network namespaces for each phy (interface) 
     sudo ip netns add ns0


### PR DESCRIPTION
## Summary
The default phy%d naming for wiphy in linux kernel depends on the value of a static variable `wiphy_counter`. Since they never attempts to decrease the value of `wiphy_counter` even a wiphy is unregistered or freed, this behavior ensures the naming and indexing for wiphy will be absolutely unique.

However, the kernel might have other projects also utilize wiphy structure, which will cause some confusion of wiphy's index and naming when using `struct wiphy`. We implement a custom-made name "vw_phy%d" for wiphy in our project, in order to seperate the naming and indexing for `struct wiphy` in our project.

As for the troublesome behavior causing by the never-decreasing index of wiphy structure as decribed in #54 , we suggest to make some changes when doing manual testing by finding the wiphy index of the interface first, and use the index to query the actual wiphy's name for the interface as describe in the changes of README.md.

[Reference](https://elixir.bootlin.com/linux/latest/source/net/wireless/core.c#L450)

## Related issue
Fix #54 