### PR TITLE
Fix buffer overflow

### DIFF
--- a/vwifi-tool.c
+++ b/vwifi-tool.c
@@ -92,7 +92,7 @@ bool denylist_send(char *denylist)
     nlh->nlmsg_pid = getpid();
     nlh->nlmsg_flags = 0;
 
-    strncpy(NLMSG_DATA(nlh), denylist, NLMSG_SPACE(MAX_PAYLOAD));
+    strncpy(NLMSG_DATA(nlh), denylist, MAX_PAYLOAD);
 
     struct iovec iov = {
         .iov_base = (void *) nlh,


### PR DESCRIPTION
When compiling, the following warning message is generated: "warning: ‘strncpy’ writing 1040 bytes into a region of size 1024 overflows the destination"
This is because calloc allocates NLMSG_SPACE(MAX_PAYLOAD) space for nlh, which includes the space for the header, so the actual space available for the message is only MAX_PAYLOAD.
@vax-r 