### PR TITLE
Support data rate and MCS

### DIFF
--- a/vwifi.c
+++ b/vwifi.c
@@ -1219,7 +1219,9 @@ static int vwifi_get_station(struct wiphy *wiphy,
                     BIT_ULL(NL80211_STA_INFO_TX_BYTES) |
                     BIT_ULL(NL80211_STA_INFO_RX_BYTES) |
                     BIT_ULL(NL80211_STA_INFO_SIGNAL) |
-                    BIT_ULL(NL80211_STA_INFO_INACTIVE_TIME);
+                    BIT_ULL(NL80211_STA_INFO_INACTIVE_TIME)| 
+                    BIT_ULL(NL80211_STA_INFO_RX_BITRATE)|
+                    BIT_ULL(NL80211_STA_INFO_TX_BITRATE);
 
     if (vif->sme_state == SME_CONNECTED) {
         sinfo->filled |= BIT_ULL(NL80211_STA_INFO_CONNECTED_TIME);
@@ -1245,8 +1247,31 @@ static int vwifi_get_station(struct wiphy *wiphy,
     /* For CFG80211_SIGNAL_TYPE_MBM, value is expressed in dBm */
     sinfo->signal = rand_int_smooth(-100, -30, jiffies);
     sinfo->inactive_time = jiffies_to_msecs(jiffies - vif->active_time);
-    /* TODO: Emulate rate and mcs */
+    /* 
+     * Using 802.11n (HT) as the PHY, configure as follows:
+     *
+     * Modulation: 64-QAM
+     * Data Bandwidth: 20MHz
+     * Number of Spatial Streams: 4
+     * 
+     * According to the 802.11n (HT) modulation table, we have:
+     *
+     * Number of Data Subcarriers: 52
+     * Number of Coded Bits per Subcarrier per Stream: 6
+     * Coding: 6
+     * OFDM Symbol Duration: 3.2 µs
+     * Guard Interval Duration: 0.8 µs 
+     * Thus, the data rate is 260 Mbps.
+     */
+    sinfo->rxrate.flags |= RATE_INFO_FLAGS_MCS;
+    sinfo->rxrate.mcs = 31;
+    sinfo->rxrate.bw = RATE_INFO_BW_20;
+    sinfo->rxrate.n_bonded_ch = 1;
 
+    sinfo->txrate.flags |= RATE_INFO_FLAGS_MCS;
+    sinfo->txrate.mcs = 31;
+    sinfo->txrate.bw = RATE_INFO_BW_20;
+    sinfo->txrate.n_bonded_ch = 1;
     return 0;
 }
 

--- a/vwifi.c
+++ b/vwifi.c
@@ -1258,7 +1258,7 @@ static int vwifi_get_station(struct wiphy *wiphy,
      *
      * Number of Data Subcarriers: 52
      * Number of Coded Bits per Subcarrier per Stream: 6
-     * Coding: 6
+     * Coding: 5/6
      * OFDM Symbol Duration: 3.2 µs
      * Guard Interval Duration: 0.8 µs 
      * Thus, the data rate is 260 Mbps.

--- a/vwifi.c
+++ b/vwifi.c
@@ -1219,8 +1219,8 @@ static int vwifi_get_station(struct wiphy *wiphy,
                     BIT_ULL(NL80211_STA_INFO_TX_BYTES) |
                     BIT_ULL(NL80211_STA_INFO_RX_BYTES) |
                     BIT_ULL(NL80211_STA_INFO_SIGNAL) |
-                    BIT_ULL(NL80211_STA_INFO_INACTIVE_TIME)| 
-                    BIT_ULL(NL80211_STA_INFO_RX_BITRATE)|
+                    BIT_ULL(NL80211_STA_INFO_INACTIVE_TIME) |
+                    BIT_ULL(NL80211_STA_INFO_RX_BITRATE) |
                     BIT_ULL(NL80211_STA_INFO_TX_BITRATE);
 
     if (vif->sme_state == SME_CONNECTED) {
@@ -1247,20 +1247,20 @@ static int vwifi_get_station(struct wiphy *wiphy,
     /* For CFG80211_SIGNAL_TYPE_MBM, value is expressed in dBm */
     sinfo->signal = rand_int_smooth(-100, -30, jiffies);
     sinfo->inactive_time = jiffies_to_msecs(jiffies - vif->active_time);
-    /* 
+    /*
      * Using 802.11n (HT) as the PHY, configure as follows:
      *
      * Modulation: 64-QAM
      * Data Bandwidth: 20MHz
      * Number of Spatial Streams: 4
-     * 
+     *
      * According to the 802.11n (HT) modulation table, we have:
      *
      * Number of Data Subcarriers: 52
      * Number of Coded Bits per Subcarrier per Stream: 6
      * Coding: 5/6
      * OFDM Symbol Duration: 3.2 µs
-     * Guard Interval Duration: 0.8 µs 
+     * Guard Interval Duration: 0.8 µs
      * Thus, the data rate is 260 Mbps.
      */
     sinfo->rxrate.flags |= RATE_INFO_FLAGS_MCS;

--- a/vwifi.c
+++ b/vwifi.c
@@ -1262,6 +1262,9 @@ static int vwifi_get_station(struct wiphy *wiphy,
      * OFDM Symbol Duration: 3.2 µs
      * Guard Interval Duration: 0.8 µs
      * Thus, the data rate is 260 Mbps.
+     * MCS table, Data Rate Formula :
+     * https://semfionetworks.com/blog/mcs-table-updated-with-80211ax-data-rates/
+     * IEEE 802.11n : https://zh.wikipedia.org/zh-tw/IEEE_802.11n
      */
     sinfo->rxrate.flags |= RATE_INFO_FLAGS_MCS;
     sinfo->rxrate.mcs = 31;


### PR DESCRIPTION
Using 802.11n (HT) as the PHY, configure as follows:

Modulation: 64-QAM
Data Bandwidth: 20MHz
Number of Spatial Streams: 4

According to the 802.11n (HT) modulation table, we have:

Number of Data Subcarriers: 52
Number of Coded Bits per Subcarrier per Stream: 6
Coding: $\frac{5}{6}$
OFDM Symbol Duration: 3.2 µs
Guard Interval Duration: 0.8 µs

Using these parameters and the formula, the calculated data rate is 260 Mbps, which matches the displayed result.
![image](https://github.com/sysprog21/vwifi/assets/56495126/4087a266-60e3-4cc5-95da-9aaa71185a42)
![image](https://github.com/sysprog21/vwifi/assets/56495126/472f708e-13fe-4f48-894b-a3f572157cdf)

ref : 
[MCS Table](https://mcsindex.net/) 

Cc. @willwillhi1 