### PR TITLE
Support transmit power

### DIFF
--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -24,6 +24,11 @@ if [ $final_ret -eq 0 ]; then
     # to avoid device or resource busy error
     sleep 0.5
 
+    # set transmit power (mBm)
+    sudo iw dev vw0 set txpower auto
+    sudo iw dev vw1 set txpower fixed 1200
+    sudo iw dev vw2 set txpower fixed 1300
+
     # get phy number of each interface
     sudo iw dev > device.log
     vw0_phy=$(get_wiphy_name vw0)


### PR DESCRIPTION
Add `tx_power` to the virtual interface to describe the device's transmit power.

Implement `vwifi_set_tx_power` and `vwifi_get_tx_power` to correspond to [`set_tx_power` ](https://elixir.bootlin.com/linux/v6.9/source/drivers/net/wireless/microchip/wilc1000/cfg80211.c#L1655)and [`get_tx_power`](https://elixir.bootlin.com/linux/v6.9/source/drivers/net/wireless/microchip/wilc1000/cfg80211.c#L1687) in [cfg80211_ops](https://elixir.bootlin.com/linux/v6.9/source/include/net/cfg80211.h#L4574), respectively.
`vwifi_set_tx_power` can set the device's transmit power, while `vwifi_get_tx_power` can retrieve the transmit power information.

The transmit power can be set using the **iwconfig vwn txpower** command.

```
phy#12
	Interface vw2
		ifindex 14
		wdev 0xc00000001
		addr 00:76:77:32:00:00
		type managed
		txpower 13.00 dBm
phy#11
	Interface vw1
		ifindex 13
		wdev 0xb00000001
		addr 00:76:77:31:00:00
		type managed
		txpower 12.00 dBm
phy#10
	Interface vw0
		ifindex 12
		wdev 0xa00000001
		addr 00:76:77:30:00:00
		type managed
		txpower 11.00 dBm
```
