### PR TITLE
Migrate to CodeQL Action v2

### DIFF
--- a/.ci/check-format.sh
+++ b/.ci/check-format.sh
@@ -2,7 +2,7 @@
 
 SOURCES=$(find $(git rev-parse --show-toplevel) | egrep "\.(cpp|cc|c|h)\$")
 
-CLANG_FORMAT=$(which clang-format-12)
+CLANG_FORMAT=$(which clang-format-18)
 if [ $? -ne 0 ]; then
     CLANG_FORMAT=$(which clang-format)
     if [ $? -ne 0 ]; then

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -47,7 +47,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -60,6 +60,6 @@ jobs:
     #     ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
       - name: validate coding style and functionality
         run: |
-            sudo apt-get install -q -y clang-format-12
+            sudo apt-get install -q -y clang-format-18
             .ci/check-format.sh
             .ci/build-n-run.sh
         shell: bash


### PR DESCRIPTION
New CodeQL analysis capabilities will only be available to users of v3.

See https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/