### PR TITLE
Fix typo in README: 'wnat' changed to 'want'

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,7 +699,7 @@ We need a filesystem overlay for putting our `vwifi` kernel module and some user
 Also, we need network applications like `iw`, `hostapd` and `wpa_supplicant`.
 ```
 System configuration ---> Run a getty (login prompt) after boot ---> TTY port ---> ttyS0
-System configuration ---> Root filesystem overlay directories ---> <the place you wnat>
+System configuration ---> Root filesystem overlay directories ---> <the place you want>
 Kernel ---> Linux Kernel ---> no
 Target packages ---> Networking applications ---> hostapd
 Target packages ---> Networking applications ---> iw


### PR DESCRIPTION
Corrected a minor typo in the README file:
- Replaced "wnat" with "want" in the "Root filesystem overlay directories" section.

This improves the clarity of the configuration instructions.