### PR TITLE
Support Linux 6.15 about hrtimer_init

### DIFF
--- a/vwifi.c
+++ b/vwifi.c
@@ -1677,8 +1677,13 @@ static int vwifi_start_ap(struct wiphy *wiphy,
 
     /* Initialize hrtimer of beacon */
     pr_info("vwifi: init beacon_timer.\n");
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+    hrtimer_setup(&vif->beacon_timer, vwifi_beacon, CLOCK_MONOTONIC,
+                  HRTIMER_MODE_ABS_SOFT);
+#else
     hrtimer_init(&vif->beacon_timer, CLOCK_MONOTONIC, HRTIMER_MODE_ABS_SOFT);
     vif->beacon_timer.function = vwifi_beacon;
+#endif
 
     if (!hrtimer_is_queued(&vif->beacon_timer)) {
         u64 tsf, until_tbtt;


### PR DESCRIPTION
To align with the best practices recommended by Linux kernel v6.15 API. This commit replaces the deprecated hrtimer_init() with hrtimer_setup() which was introduced as its functional replacement.The new API requires a hrtimer_callback function pointer as one of the parameters. After examining the surrounding codebase,the appropriate callback function has been identified and passed accordingly.

ref:
https://github.com/torvalds/linux/commit/9779489a31d77a7b9cb6f20d2d2caced4e29dbe6