### PR TITLE
vwifi: Use timer_delete_sync() on Linux >= 6.1.84 for scan timers

### DIFF
--- a/vwifi.c
+++ b/vwifi.c
@@ -1974,7 +1974,11 @@ static int vwifi_delete_interface(struct vwifi_vif *vif)
 
         cancel_work_sync(&vif->ws_scan);
         cancel_work_sync(&vif->ws_scan_timeout);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 84)
+        timer_delete_sync(&vif->scan_complete);
+#else
         del_timer_sync(&vif->scan_complete);
+#endif
 
         /* If there's a pending scan, call cfg80211_scan_done to finish it. */
         if (vif->scan_request) {
@@ -1985,7 +1989,11 @@ static int vwifi_delete_interface(struct vwifi_vif *vif)
         }
 
         /* Make sure that no work is queued */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 84)
+        timer_delete_sync(&vif->scan_timeout);
+#else
         del_timer_sync(&vif->scan_timeout);
+#endif
         cancel_work_sync(&vif->ws_connect);
         cancel_work_sync(&vif->ws_disconnect);
 


### PR DESCRIPTION
To align with the changes introduced in Linux kernel version 6.15, this commit replaces the deprecated del_timer_sync() with timer_delete_sync(), which now serves as its functional replacement. The function parameters remain unchanged, making this a direct drop-in fix.

ref:
https://github.com/torvalds/linux/commit/9b13df3fb64ee95e2397585404e442afee2c7d4f