### PR TITLE
Add HT MCS table and helper for 802.11n bitrate lookup

### DIFF
--- a/vwifi.c
+++ b/vwifi.c
@@ -1974,7 +1974,11 @@ static int vwifi_delete_interface(struct vwifi_vif *vif)
 
         cancel_work_sync(&vif->ws_scan);
         cancel_work_sync(&vif->ws_scan_timeout);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 84)
+        timer_delete_sync(&vif->scan_complete);
+#else
         del_timer_sync(&vif->scan_complete);
+#endif
 
         /* If there's a pending scan, call cfg80211_scan_done to finish it. */
         if (vif->scan_request) {
@@ -1985,7 +1989,11 @@ static int vwifi_delete_interface(struct vwifi_vif *vif)
         }
 
         /* Make sure that no work is queued */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 84)
+        timer_delete_sync(&vif->scan_timeout);
+#else
         del_timer_sync(&vif->scan_timeout);
+#endif
         cancel_work_sync(&vif->ws_connect);
         cancel_work_sync(&vif->ws_disconnect);
 


### PR DESCRIPTION
This patch adds a static HT MCS table (indexes 0–31) for 802.11n in 20 MHz bandwidth,
covering both long GI (0.8 µs) and short GI (0.4 µs) variants.

Also introduces `get_ht_bitrate_kbps()` for retrieving the bitrate based on the
configured GI and current MCS index in `vwifi_vif`.
