### PR TITLE
Drop .owner for kernel >= 6.4

### DIFF
--- a/vwifi.c
+++ b/vwifi.c
@@ -3341,7 +3341,9 @@ static struct virtio_driver virtio_vwifi = {
     .feature_table = features,
     .feature_table_size = ARRAY_SIZE(features),
     .driver.name = KBUILD_MODNAME,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
     .driver.owner = THIS_MODULE,
+#endif
     .id_table = id_table,
     .probe = vwifi_virtio_probe,
     .remove = vwifi_virtio_remove,


### PR DESCRIPTION
Kernel 6.4+ sets .owner automatically. Remove manual assignment to avoid build issues and keep compatibility with older versions.

Reference: [sysprog21/kxo#18](https://github.com/sysprog21/kxo/pull/18)