### PR TITLE
Fix incorrect conditional usage of .owner

### DIFF
--- a/vwifi.c
+++ b/vwifi.c
@@ -3341,9 +3341,7 @@ static struct virtio_driver virtio_vwifi = {
     .feature_table = features,
     .feature_table_size = ARRAY_SIZE(features),
     .driver.name = KBUILD_MODNAME,
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
     .driver.owner = THIS_MODULE,
-#endif
     .id_table = id_table,
     .probe = vwifi_virtio_probe,
     .remove = vwifi_virtio_remove,


### PR DESCRIPTION
The examples code wrapped .owner = THIS_MODULE inside version checks, suggesting that it is no longer needed after v6.4. This is only true for driver types where the driver core sets .owner automatically (e.g. platform and i2c drivers).

For structures such as struct file_operations, .owner must still be set explicitly by the user. Without it, module reference counting will be broken, allowing a module to be unloaded while still in use, which can lead to kernel panics.

For struct class, the core can safely omit .owner, but explicitly setting it remains correct and safe. Adding conditional #if checks around it only makes the examples harder to read and more confusing for readers.

Remove the unnecessary version guards and unconditionally sets .owner = THIS_MODULE in the affected example code.

Ref: sysprog21/lkmpg#348

Signed-off-by: @visitorckw