### PR TITLE
Update README with virtio config and bridge setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,7 +652,10 @@ Enter the top directory of the Linux kernel source and use the following command
 ```shell
 $ make menuconfig
 ```
-The default kernel configuration will work for our testing environment, so just click `save` and we get `.config` on the top directory.
+To allow virtio device to be bound to vwifi driver, please ensure the virtio network driver is disabled before you click `save`. By excluding the virtio network driver, you should spot `CONFIG_VIRTIO_NET=n` in the `.config` file on the top directory.
+```
+Device Drivers ---> Network device support ---> Virtio network driver ---> no
+```
 
 Before building the kernel, please ensure that all the needed packages or libraries have been installed in your machine.
 
@@ -748,6 +751,11 @@ Attach three `tap` devices on `bridge` device:
 $ sudo ip link set tap0 master br0
 $ sudo ip link set tap1 master br0
 $ sudo ip link set tap2 master br0
+```
+
+Start `bridge` device:
+```shell
+$ sudo ip link set br0 up
 ```
 
 ### Start VM with Qemu

--- a/vwifi.c
+++ b/vwifi.c
@@ -2019,6 +2019,9 @@ static int vwifi_delete_interface(struct vwifi_vif *vif)
 /* Set transmit power for the virtual interface */
 static int vwifi_set_tx_power(struct wiphy *wiphy,
                               struct wireless_dev *wdev,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
+                              int radio_idx,
+#endif
                               enum nl80211_tx_power_setting type,
                               int mbm)
 {
@@ -2064,6 +2067,9 @@ static int vwifi_set_tx_power(struct wiphy *wiphy,
 /* Get transmit power from the virtual interface */
 static int vwifi_get_tx_power(struct wiphy *wiphy,
                               struct wireless_dev *wdev,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
+                              int radio_idx,
+#endif
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
                               unsigned int link_id,
 #endif


### PR DESCRIPTION
Add instructions to disable the virtio network driver so the virtio device can bind to the vwifi driver. Document the expected CONFIG setting in .config and provide menuconfig navigation steps.

Also include steps to bring up the bridge device (br0) required for networking setup.