### PR TITLE
Update README with virtio config and bridge setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,7 +652,10 @@ Enter the top directory of the Linux kernel source and use the following command
 ```shell
 $ make menuconfig
 ```
-The default kernel configuration will work for our testing environment, so just click `save` and we get `.config` on the top directory.
+To allow virtio device to be bound to vwifi driver, please ensure the virtio network driver is disabled before you click `save`. By excluding the virtio network driver, you should spot `CONFIG_VIRTIO_NET=n` in the `.config` file on the top directory.
+```
+Device Drivers ---> Network device support ---> Virtio network driver ---> no
+```
 
 Before building the kernel, please ensure that all the needed packages or libraries have been installed in your machine.
 
@@ -748,6 +751,11 @@ Attach three `tap` devices on `bridge` device:
 $ sudo ip link set tap0 master br0
 $ sudo ip link set tap1 master br0
 $ sudo ip link set tap2 master br0
+```
+
+Start `bridge` device:
+```shell
+$ sudo ip link set br0 up
 ```
 
 ### Start VM with Qemu


### PR DESCRIPTION
In Linux driver binding, once a device ID matches one of those IDs supported by a driver, the driver is bound and the driver's probe() is invoked. If a device is already bound to a driver, subsequent binding attempts will skip the device. Thus, with CONFIG_VIRTIO_NET=y, virtio_net binds to the virtio device first, causing the virtio device to be skipped when vwifi later attempts to bind.

Add instructions to disable the virtio_net driver so the virtio device can bind to the vwifi driver. Document the expected CONFIG setting in .config and provide menuconfig navigation steps.

Also include steps to bring up the bridge device (br0) required for networking setup, enabling traffic to be ready to flow between the host and virtual machines via virtio-backed interfaces.